### PR TITLE
Fix license check for gradle multi-projects.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -522,7 +522,7 @@ license {
             files = project.files("build.gradle.kts", "settings.gradle.kts")
         }
         create("workflows") {
-            files = fileTree("${project.rootDir}/.github/workflows/")
+            files = fileTree("${project.projectDir}/.github/workflows/")
         }
         create("mainInternal") {
             files = project.sourceSets.main.get().allSource.filter { !it.startsWith(project.buildDir) }


### PR DESCRIPTION
Suppose this directory structure:
/root
/root/.github/
/root/z3-turnkey/
/root/z3-turnkey/.github
/root/other-project/

Then the license check would check the "/root/.github/" directory
for license violations. But this directory is completely unrelated
to z3-turnkey! Instead it should check "/root/z3-turnkey/.github".

Fix: Switch rootDir -> projectDir