### PR TITLE
Bump z3 to 4.11.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ plugins {
 
 group = "tools.aqua"
 
-val z3Version = "4.9.0"
+val z3Version = "4.11.2"
 val turnkeyVersion = ""
 
 version = "$z3Version$turnkeyVersion"


### PR DESCRIPTION
Simple version bump to 4.11.2, closes #14.
Would be great if we could get this published to package repos!