### PR TITLE
Update Compatibility matrix to indicate Linux/x86 works

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ At the moment, platform support is as follows:
 
 | Operating System | x86 | AMD64 | AARCH64 |
 | ---------------- | :-: | :---: | :-----: |
-| Linux            |     |   ✓   |         |
+| Linux            |  ✓  |   ✓   |         |
 | macOS            |     |   ✓   |    ✓    |
 | Windows          |  ✓  |   ✓   |         |
 


### PR DESCRIPTION
This seems to work fine for me on Ubuntu/x86.

Not sure if I'm getting lucky, but it seems like the matrix might just be out of date?